### PR TITLE
maimai: fetch more internal levels

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,8 +30,10 @@
         "yaml": "^2.1.1"
       },
       "devDependencies": {
+        "@tsconfig/node16": "^1.0.3",
         "@types/download": "^8.0.1",
         "@types/google-spreadsheet": "^3.2.2",
+        "@types/node": "^16.18.4",
         "@types/shelljs": "^0.8.11",
         "@typescript-eslint/eslint-plugin": "^5.29.0",
         "@typescript-eslint/parser": "^5.29.0",
@@ -288,9 +290,9 @@
       "dev": true
     },
     "node_modules/@tsconfig/node16": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.2.tgz",
-      "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
+      "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
       "dev": true
     },
     "node_modules/@types/debug": {
@@ -370,9 +372,9 @@
       "integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA=="
     },
     "node_modules/@types/node": {
-      "version": "17.0.23",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.23.tgz",
-      "integrity": "sha512-UxDxWn7dl97rKVeVS61vErvw086aCYhDLyvRQZ5Rk65rZKepaFdm53GeqXaKBuOhED4e9uWq34IC3TdSdJJ2Gw=="
+      "version": "16.18.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.4.tgz",
+      "integrity": "sha512-9qGjJ5GyShZjUfx2ArBIGM+xExdfLvvaCyQR0t6yRXKPcWCVYF/WemtX/uIU3r7FYECXRXkIiw2Vnhn6y8d+pw=="
     },
     "node_modules/@types/shelljs": {
       "version": "0.8.11",
@@ -7538,9 +7540,9 @@
       "dev": true
     },
     "@tsconfig/node16": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.2.tgz",
-      "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
+      "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
       "dev": true
     },
     "@types/debug": {
@@ -7620,9 +7622,9 @@
       "integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA=="
     },
     "@types/node": {
-      "version": "17.0.23",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.23.tgz",
-      "integrity": "sha512-UxDxWn7dl97rKVeVS61vErvw086aCYhDLyvRQZ5Rk65rZKepaFdm53GeqXaKBuOhED4e9uWq34IC3TdSdJJ2Gw=="
+      "version": "16.18.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.4.tgz",
+      "integrity": "sha512-9qGjJ5GyShZjUfx2ArBIGM+xExdfLvvaCyQR0t6yRXKPcWCVYF/WemtX/uIU3r7FYECXRXkIiw2Vnhn6y8d+pw=="
     },
     "@types/shelljs": {
       "version": "0.8.11",

--- a/package.json
+++ b/package.json
@@ -76,8 +76,10 @@
   "author": "Raku Zeta <zetaraku@gmail.com>",
   "license": "MIT",
   "devDependencies": {
+    "@tsconfig/node16": "^1.0.3",
     "@types/download": "^8.0.1",
     "@types/google-spreadsheet": "^3.2.2",
+    "@types/node": "^16.18.4",
     "@types/shelljs": "^0.8.11",
     "@typescript-eslint/eslint-plugin": "^5.29.0",
     "@typescript-eslint/parser": "^5.29.0",

--- a/src/maimai/fetch-internal-levels.ts
+++ b/src/maimai/fetch-internal-levels.ts
@@ -70,7 +70,6 @@ async function parseLevelSheet(sheet: GoogleSpreadsheetWorksheet) {
       const cell = sheet.getCell(row, col);
       const chartConstantCell = sheet.getCell(row, col + 5);
 
-      // backgroundColor notes the start of a new difficulty/category group
       if (cell.value !== null
           && !chartConstantCell.formulaError
           && !Number.isNaN(parseFloat(chartConstantCell.value as string))


### PR DESCRIPTION
This PR fetches more internal levels from the RCMF spreadsheet using the `'14以上', '13+', '13', '12+', '12'` sheets, since the `Tmai` sheet doesn't include everything.