### PR TITLE
Update fetch-internal-levels.ts

### DIFF
--- a/src/maimai/fetch-internal-levels.ts
+++ b/src/maimai/fetch-internal-levels.ts
@@ -259,7 +259,7 @@ async function fetchSheetsV8() {
     }),
     ...await extractRecords({
       spreadsheet, sheetName: '13',
-      dataIndexes: [0, 7, 14, 21, 28, 35, 42, 50],
+      dataIndexes: [0, 7, 14, 21, 28, 35],
       dataOffsets: [0, 2, 3, 5],
     }),
     ...await extractRecords({


### PR DESCRIPTION
Due to the change of the Maimai internal levels sheet, the wrong data index will cause a Google spreadsheet out-of-bounds error.
This branch fixed the error.